### PR TITLE
Add coverage script

### DIFF
--- a/jest.config.json
+++ b/jest.config.json
@@ -1,0 +1,8 @@
+{
+  "name": "discover-dapps",
+  "jest": {
+    "verbose": true
+  },
+  "collectCoverage": true,
+  "coverageDirectory": "coverage"
+}

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "start": "react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test",
+    "coverage": "react-scripts test --coverage",
     "eject": "react-scripts eject",
     "predeploy": "npm run build",
     "deploy": "gh-pages -d build"


### PR DESCRIPTION
- Adds coverage script that uses coverage from jest (the testing tool used by react-scripts folder)

The coverage folder is in gitignore, I think is better to only share the coverage % report with a badge like most of the github repositories.